### PR TITLE
Add new rake task to automatically update video.js

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,6 +54,7 @@ namespace :videojs do
         end
       end
       sh "rm -f #{jsdev}"
+      sh "rm -f #{VIDEO_JS_RAILS_HOME}/vendor/assets/javascripts/video.js"
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ namespace :videojs do
     end
 
     sh "git add ."
-    sh "git ci -m 'Update to video.js #{tag}'"
+    sh "git commit -m 'Update to video.js #{tag}'"
     puts "* Done.  Now run 'rake release' to push to rubygems."
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -27,13 +27,12 @@ namespace :videojs do
       sh "cp #{VIDEO_JS_HOME}/dist/video-js/font/* #{VIDEO_JS_RAILS_HOME}/vendor/assets/fonts/"
       sh "cp #{VIDEO_JS_HOME}/dist/video-js/video-js.css #{VIDEO_JS_RAILS_HOME}/vendor/assets/stylesheets/"
       sh "cp #{VIDEO_JS_HOME}/dist/video-js/video-js.swf #{VIDEO_JS_RAILS_HOME}/vendor/assets/javascripts/"
-      sh "cp #{VIDEO_JS_HOME}/dist/video-js/video.dev.js #{VIDEO_JS_RAILS_HOME}/vendor/assets/javascripts/video.js"
+      sh "cp #{VIDEO_JS_HOME}/dist/video-js/video.dev.js #{VIDEO_JS_RAILS_HOME}/vendor/assets/javascripts/"
 
       # Now, perform some asset_path and other substitutions
-      css = "#{VIDEO_JS_RAILS_HOME}/vendor/assets/stylesheets/video-js.css"
-
       puts
       puts "* Updating videojs-css.erb for Rails asset pipeline"
+      css = "#{VIDEO_JS_RAILS_HOME}/vendor/assets/stylesheets/video-js.css"
       File.open("#{css}.erb", 'w') do |out|
         File.foreach(css) do |line|
           # Handle fonts => url('<%= asset_path('vjs.woff') %>') format('woff')
@@ -42,6 +41,19 @@ namespace :videojs do
         end
       end
       sh "rm -f #{css}"
+
+      puts
+      puts "* Updating video.js.erb for Rails asset pipeline"
+      jsdev = "#{VIDEO_JS_RAILS_HOME}/vendor/assets/javascripts/video.dev.js"
+      jserb = "#{VIDEO_JS_RAILS_HOME}/vendor/assets/javascripts/video.js.erb"
+      File.open(jserb, 'w') do |out|
+        File.foreach(jsdev) do |line|
+          # Handle swf => asset_path('video-js.swf')
+          out <<
+            line.sub(/(videojs\.options\['flash'\]\['swf'\]\s*=\s*).*/, %q(\1"<%= asset_path('video-js.swf') %>";))
+        end
+      end
+      sh "rm -f #{jsdev}"
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,64 @@
 require 'bundler/gem_tasks'
+
+# Build the version of video.js and tag us to match
+
+VIDEO_JS_RAILS_HOME = File.expand_path(File.dirname(__FILE__))
+VIDEO_JS_HOME = File.expand_path('../video.js', VIDEO_JS_RAILS_HOME)
+
+VIDEO_JS_RAKE_USAGE = "Usage: rake videojs:update TAG=v4.12.5"
+
+namespace :videojs do
+  task :update => [:build, :commit]
+
+  task :build do
+    tag = ENV['TAG'] or abort VIDEO_JS_RAKE_USAGE
+    Dir.chdir(VIDEO_JS_HOME) do
+      puts "* Building video.js #{tag} using grunt"
+      unless ENV['NOBUILD']
+        sh "git checkout -q master"
+        sh "git pull -q"
+        sh "git checkout -q #{tag}"
+        sh "grunt"
+      end
+
+      # Copy files into our Rails structure
+      puts
+      puts "* Copying files to vendor/assets"
+      sh "cp #{VIDEO_JS_HOME}/dist/video-js/font/* #{VIDEO_JS_RAILS_HOME}/vendor/assets/fonts/"
+      sh "cp #{VIDEO_JS_HOME}/dist/video-js/video-js.css #{VIDEO_JS_RAILS_HOME}/vendor/assets/stylesheets/"
+      sh "cp #{VIDEO_JS_HOME}/dist/video-js/video-js.swf #{VIDEO_JS_RAILS_HOME}/vendor/assets/javascripts/"
+      sh "cp #{VIDEO_JS_HOME}/dist/video-js/video.dev.js #{VIDEO_JS_RAILS_HOME}/vendor/assets/javascripts/video.js"
+
+      # Now, perform some asset_path and other substitutions
+      css = "#{VIDEO_JS_RAILS_HOME}/vendor/assets/stylesheets/video-js.css"
+
+      puts
+      puts "* Updating videojs-css.erb for Rails asset pipeline"
+      File.open("#{css}.erb", 'w') do |out|
+        File.foreach(css) do |line|
+          # Handle fonts => url('<%= asset_path('vjs.woff') %>') format('woff')
+          out <<
+            line.gsub(/url\(('*)font\/(vjs[^\)]+)\)\s+(format[^\)]+\))/, 'url(<%= asset_path(\1\2) %>) \3')
+        end
+      end
+      sh "rm -f #{css}"
+    end
+  end
+
+  task :commit do
+    tag = ENV['TAG'] or abort VIDEO_JS_RAKE_USAGE
+
+    # Update the gem version
+    version_file = "#{VIDEO_JS_RAILS_HOME}/lib/videojs_rails/version.rb"
+    lines = File.read(version_file)
+    File.open(version_file, 'w') do |out|
+      version_num = tag.sub(/^v/,'')  # lose the "v" from the tag
+      puts "* Setting gem version = #{version_num}"
+      out << lines.sub(/(VERSION\s*=\s*)\S+/, "\\1'#{version_num}'")
+    end
+
+    sh "git add ."
+    sh "git ci -m 'Update to video.js #{tag}'"
+    puts "* Done.  Now run 'rake release' to push to rubygems."
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ namespace :videojs do
         File.foreach(css) do |line|
           # Handle fonts => url('<%= asset_path('vjs.woff') %>') format('woff')
           out <<
-            line.gsub(/url\(('*)font\/(vjs[^\)]+)\)\s+(format[^\)]+\))/, 'url(<%= asset_path(\1\2) %>) \3')
+            line.gsub(/url\(('*)font\/(vjs[^\)]+)\)(\s+format[^\)]+\))?/, 'url(<%= asset_path(\1\2) %>)\3')
         end
       end
       sh "rm -f #{css}"

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-# VideoJS for Asset Pipeline
+# VideoJS for Rails Asset Pipeline
+
+Supports Rails 3.x and 4.x
 
 ## Installation
 
@@ -30,8 +32,6 @@ And that resource to application.css file
 */
 ```
 
-_currently skins are not implemented (after migrate to 4.1 version)_
-
 And to production.rb add this line
 
 ```ruby
@@ -54,7 +54,7 @@ If you want add a callback if user don't support JavaScript use block with displ
 
 ## Captions
 
-This is currently experimental function.
+This is currently an experimental function.
 
 ```erb
 <%= videojs_rails sources: { mp4: "http://domain.com/path/to/video.mp4" }, width:"400", captions: { en: { src: "http://domain.com/path/to/captions.vvt", label: "English" }, default_caption_language: :en } %>
@@ -66,23 +66,32 @@ http://videojs.com/
 http://videojs.com/#getting-started
 
 
-## Update from video.js release
+## Updating this gem to the latest video.js release
 
-### Generate video.js distribution files
+### Clone this repository
 
-* Checkout release tag e.g. `git checkout v4.6.1`.
-* Run the build i.e. `grunt`.
+    git clone https://github.com/seanbehan/videojs_rails.git
 
-### Copy video.js files into videojs_rails
+### Clone video.js repository
 
-    $ cp $VIDEO_JS_HOME/dist/video-js/video-js.swf $VIDEO_JS_RAILS_HOME/vendor/assets/flash/
-    $ cp $VIDEO_JS_HOME/dist/video-js/font/* $VIDEO_JS_RAILS_HOME/vendor/assets/fonts/
-    $ cp $VIDEO_JS_HOME/dist/video-js/video.dev.js $VIDEO_JS_RAILS_HOME/vendor/assets/javascripts/video.js.erb
-    $ cp $VIDEO_JS_HOME/dist/video-js/video-js.css $VIDEO_JS_RAILS_HOME/vendor/assets/stylesheets/video-js.css.erb
+    git clone https://github.com/videojs/video.js.git
 
-### Update video.js files with ERB from previous version of videojs_rails
 
-The following files need to be modified to use the Rails `asset_path` helper e.g. for the location of the Flash player SWF file and for the location of the various font files:
+### Run the rake videojs:update task with the tag
 
-* $VIDEO_JS_RAILS_HOME/vendor/assets/javascripts/video.js.erb
-* $VIDEO_JS_RAILS_HOME/vendor/assets/stylesheets/video-js.css.erb
+    TAG=v4.12.5
+    rake videojs:update
+
+Note: The build will fail if you don't have `grunt` installed.  To install it:
+
+    cd ../video.js
+    npm install -g grunt
+
+### Make sure everything is added to git
+
+    git add .
+    git ci -m "Update to $TAG"
+
+### Push to rubygems
+
+    rake release


### PR DESCRIPTION
Hi, I added a new rake task to automatically update the gem:

    rake videojs:update TAG=v4.12.5

This will pull down the latest video.js code, checkout the corresponding tag, and then perform substitutions for the Rails pipeline such as using `asset_path()`

If you accept the pull request, can you also update to the latest as shown above?

Thanks,
Nate