### PR TITLE
Adds boolean attrs 'controls', 'autoplay', and 'loop' only if present…

### DIFF
--- a/app/views/videojs_rails/_videojs_rails.html.erb
+++ b/app/views/videojs_rails/_videojs_rails.html.erb
@@ -1,13 +1,15 @@
 <div class="video-js-box">
 	<video
 		id="<%=options[:id]%>"
-		class="<%= options[:classes] %> video-js vjs-default-skin"
-		<%= "controls" if !!options[:controls] %>
-		preload="<%=options[:preload]%>"
-		width="<%=options[:width]%>"
-		height="<%=options[:height]%>"
-		poster="<%= options[:poster] %>"
-		data-setup="<%= options[:setup] %>"
+		class="<%= @options[:classes] %> video-js vjs-default-skin" 
+    preload="auto" 
+    width="<%=@options[:width]%>" 
+    height="<%=@options[:height]%>" 
+    poster="<%= @options[:poster] %>" 
+    data-setup="<%= @options[:setup] || '{}' %>" 
+    <%= "controls" if !!@options[:controls] %> 
+    <%= "autoplay" if !!@options[:autoplay] %> 
+    <%= "loop" if !!@options[:loop] %>
 	>
 		<% if options[:sources] %>
 			<%- options[:sources].each do |type, source| %>


### PR DESCRIPTION
Original seemed to always include 'controls' by default for the html5 element. I needed an autoplaying and looping video, so I overwrote the partial in my project. Decided to fork it and put it here instead!