### PR TITLE
support sources as an Array 

### DIFF
--- a/lib/videojs_rails/tags/source.rb
+++ b/lib/videojs_rails/tags/source.rb
@@ -2,36 +2,27 @@ module VideojsRails
   module Tags
     class Source < Tag
       def initialize(video_type, options)
-        @video_type = video_type
-        parse_options(options)
+        @attributes = prepare_attributes(video_type, options)
       end
 
       def to_html
-        tag :source, attributes
+        tag :source, @attributes
       end
 
       private
 
-      attr_reader :video_type, :src
-
-      def parse_options(options)
+      def prepare_attributes(video_type, options)
         case options
-        when String, Symbol
-          @src = options
-        else
-          raise ArgumentError
+          when String, Symbol
+            {}.tap do |attributes|
+              attributes[:src] = options
+              attributes[:type] = "video/#{video_type}"
+            end
+          when Hash
+            options
+          else
+            raise ArgumentError
         end
-      end
-
-      def type
-        "video/#{video_type}"
-      end
-
-      def attributes
-        {
-          src: src,
-          type: type
-        }
       end
     end
   end

--- a/lib/videojs_rails/tags/source.rb
+++ b/lib/videojs_rails/tags/source.rb
@@ -2,7 +2,8 @@ module VideojsRails
   module Tags
     class Source < Tag
       def initialize(video_type, options)
-        @attributes = prepare_attributes(video_type, options)
+        @video_type = video_type
+        @attributes = parse_options(options)
       end
 
       def to_html
@@ -11,18 +12,24 @@ module VideojsRails
 
       private
 
-      def prepare_attributes(video_type, options)
+      attr_reader :video_type
+
+      def parse_options(options)
         case options
           when String, Symbol
-            {}.tap do |attributes|
-              attributes[:src] = options
-              attributes[:type] = "video/#{video_type}"
-            end
+            {
+                src: options,
+                type: type
+            }
           when Hash
             options
           else
             raise ArgumentError
         end
+      end
+
+      def type
+        "video/#{video_type}"
       end
     end
   end

--- a/lib/videojs_rails/view_helpers.rb
+++ b/lib/videojs_rails/view_helpers.rb
@@ -21,15 +21,14 @@ module VideojsRails
     end
 
     def generate_sources(sources)
-      case sources.class
-        when Array
-          sources.each do |source|
-            concat tag(:source, source)
-          end
-        when Hash
-          sources.each do |type, source|
-            concat tag(:source, src: source, type: "video/#{ type }")
-          end
+      if sources.is_a?(Array)
+        sources.each do |source|
+          concat tag(:source, source)
+        end
+      elsif sources.is_a?(Hash)
+        sources.each do |type, source|
+          concat tag(:source, src: source, type: "video/#{ type }")
+        end
       end
     end
 

--- a/lib/videojs_rails/view_helpers.rb
+++ b/lib/videojs_rails/view_helpers.rb
@@ -1,9 +1,9 @@
 module VideojsRails
   module ViewHelpers
-      DEFAULT_OPTIONS = {
+    DEFAULT_OPTIONS = {
         controls: true,
         preload: :auto
-      }.freeze
+    }.freeze
 
     def videojs_rails(user_options, &blk)
       sources, captions, options = prepare_options(user_options)
@@ -21,9 +21,15 @@ module VideojsRails
     end
 
     def generate_sources(sources)
-      return if sources.blank?
-      sources.each do |type, source|
-        concat tag(:source, src: source, type: "video/#{ type }")
+      case sources.class
+        when Array
+          sources.each do |source|
+            concat tag(:source, source)
+          end
+        when Hash
+          sources.each do |type, source|
+            concat tag(:source, src: source, type: "video/#{ type }")
+          end
       end
     end
 
@@ -48,11 +54,11 @@ module VideojsRails
     def prepare_caption_options(src, lang, label, options)
       default_caption_language = options[:default_caption_language].try(:to_sym)
       {
-        kind: :captions,
-        src: src,
-        srclang: lang,
-        label: label,
-        default: default_caption_language == lang.to_sym
+          kind: :captions,
+          src: src,
+          srclang: lang,
+          label: label,
+          default: default_caption_language == lang.to_sym
       }
     end
 


### PR DESCRIPTION
So you can give more attributes than src and type, e.g. [src:'src.mp4', type:'video/mp4', :'data-foo' => 'bar']