### PR TITLE
Change turbolinks before-change to before-unload

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ before_change = ->
         video = videojs('example_video')
         video.dispose()
 
-$(document).on('page:before-change', before_change)
+$(document).on('page:before-unload', before_change)
 $(document).on('page:change', change)
 ```
 


### PR DESCRIPTION
Previously the player was not disposed when pressing the back button in the browser. Using before-unload instead of before-change fixes this.

Thanks @grzlus
Fixes #27 again